### PR TITLE
OHT-32 permissions

### DIFF
--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -6,20 +6,26 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader
 import ckanext.blob_storage.helpers as blobstorage_helpers
+import ckan.logic.auth as logic_auth
+from ckan.logic.auth.get import package_show
+from ckan.lib.plugins import DefaultPermissionLabels
 from giftless_client import LfsClient
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 from ckanext.oht.helpers import (
     get_dataset_from_id, get_facet_items_dict
 )
 
+
 log = logging.getLogger(__name__)
 
 
-class OHTPlugin(plugins.SingletonPlugin):
+class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IFacets, inherit=True)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IResourceController, inherit=True)
+    plugins.implements(plugins.IPermissionLabels)
+    plugins.implements(plugins.IAuthFunctions)
 
     # ITemplateHelpers
     def get_helpers(self):
@@ -58,6 +64,38 @@ class OHTPlugin(plugins.SingletonPlugin):
             _giftless_upload(context, resource, current=current)
             _update_resource_last_modified_date(resource, current=current)
         return resource
+
+    def get_dataset_labels(self, dataset_obj):
+        """
+        Stops private datasets from being visible to other members of the
+        same organisation. Only the creator and collaborators can see them.
+        """
+        labels = super(OHTPlugin, self).get_dataset_labels(dataset_obj)
+
+        if dataset_obj.owner_org:
+            labels.remove(u'member-%s' % dataset_obj.owner_org)
+            labels.append(u'creator-%s' % dataset_obj.creator_user_id)
+
+        return labels
+
+    def get_auth_functions(self):
+        return {
+            'package_update': _package_update_auth_function
+        }
+
+
+@toolkit.chained_auth_function
+def _package_update_auth_function(next_auth_function, context, data_dict):
+    user = context.get('user')
+    package = logic_auth.get_package_object(context, data_dict)
+    if not package_show(context, data_dict)['success']:
+        return {
+            'success': False,
+            'msg': toolkit._('User {} not authorized to view package {}').format(
+                user, package.id
+            )
+        }
+    return next_auth_function(context, data_dict)
 
 
 def _giftless_upload(context, resource, current=None):

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -70,13 +70,13 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         Stops private datasets from being visible to other members of the
         same organisation.
         """
-        labels = super(OHTPlugin, self).get_dataset_labels(dataset_obj)
+        labels = set(super(OHTPlugin, self).get_dataset_labels(dataset_obj))
 
         if dataset_obj.owner_org:
-            labels.remove(f'member-{dataset_obj.owner_org}')
-            labels.append(f'creator-{dataset_obj.creator_user_id}')
+            labels.discard(f'member-{dataset_obj.owner_org}')
+            labels.add(f'creator-{dataset_obj.creator_user_id}')
 
-        return labels
+        return list(labels)
 
     def get_auth_functions(self):
         return {

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -66,8 +66,13 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
 
     def get_dataset_labels(self, dataset_obj):
         """
-        Stops private datasets from being visible to other members of the
-        same organisation.
+        Stops private datasets from being visible to other members of the same
+        organisation, whilst ensuring they remain visible to the creator user.
+
+        This function is extending the default parent class behaviour found
+        in ckan.lib.plugins.DefaultPermissionLabels.  We remove the label
+        identifying the dataset as a member of the parent organisation, and
+        replace it with the label identifying the creator user id.
         """
         labels = set(super(OHTPlugin, self).get_dataset_labels(dataset_obj))
 

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -95,7 +95,9 @@ def _package_update_auth_function(context, data_dict):
     if user_obj:
         is_editor_collaborator = (
             authz.check_config_permission('allow_dataset_collaborators') and
-            authz.user_is_collaborator_on_dataset(user_obj.id, package.id, ['admin', 'editor'])
+            authz.user_is_collaborator_on_dataset(
+                user_obj.id, package.id, ['admin', 'editor']
+            )
         )
         is_dataset_creator = user_obj.id == package.creator_user_id
 

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -73,8 +73,8 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         labels = super(OHTPlugin, self).get_dataset_labels(dataset_obj)
 
         if dataset_obj.owner_org:
-            labels.remove(u'member-%s' % dataset_obj.owner_org)
-            labels.append(u'creator-%s' % dataset_obj.creator_user_id)
+            labels.remove(f'member-{dataset_obj.owner_org}')
+            labels.append(f'creator-{dataset_obj.creator_user_id}')
 
         return labels
 
@@ -91,9 +91,7 @@ def _package_update_auth_function(next_auth_function, context, data_dict):
     if not package_show(context, data_dict)['success']:
         return {
             'success': False,
-            'msg': toolkit._('User {} not authorized to view package {}').format(
-                user, package.id
-            )
+            'msg': toolkit._(f'User {user} not authorized to view package {package.id}')
         }
     return next_auth_function(context, data_dict)
 

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -68,7 +68,7 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     def get_dataset_labels(self, dataset_obj):
         """
         Stops private datasets from being visible to other members of the
-        same organisation. Only the creator and collaborators can see them.
+        same organisation.
         """
         labels = super(OHTPlugin, self).get_dataset_labels(dataset_obj)
 
@@ -86,8 +86,12 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
 
 @toolkit.chained_auth_function
 def _package_update_auth_function(next_auth_function, context, data_dict):
+    """
+    Ensures that only users who can view a dataset can edit the dataset.
+    """
     user = context.get('user')
     package = logic_auth.get_package_object(context, data_dict)
+
     if not package_show(context, data_dict)['success']:
         return {
             'success': False,

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -7,8 +7,6 @@ import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader
 import ckanext.blob_storage.helpers as blobstorage_helpers
 import ckan.logic.auth as logic_auth
-from ckan.logic.auth.create import _check_group_auth
-from ckan.logic.auth.get import package_show
 from ckan.lib.plugins import DefaultPermissionLabels
 from giftless_client import LfsClient
 from werkzeug.datastructures import FileStorage as FlaskFileStorage

--- a/ckanext/oht/templates/scheming/form_snippets/organization.html
+++ b/ckanext/oht/templates/scheming/form_snippets/organization.html
@@ -1,3 +1,0 @@
-{% ckan_extends %}
-{% block package_metadata_fields_visibility %}
-{% endblock %}

--- a/ckanext/oht/tests/__init__.py
+++ b/ckanext/oht/tests/__init__.py
@@ -1,0 +1,8 @@
+from ckan import model
+
+
+def get_context(user):
+    return {
+        'model': model,
+        'user': user if isinstance(user, str) else user['name']
+    }

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -36,7 +36,7 @@ class TestAuth():
             user=self.user_2
         )
 
-    def test_users_cant_see_other_users_datasets(self):
+    def test_users_cant_see_other_users_private_datasets(self):
 
         with pytest.raises(toolkit.NotAuthorized):
             call_auth(
@@ -52,7 +52,7 @@ class TestAuth():
                 id=self.dataset_1['id']
             )
 
-    def test_users_cant_edit_other_users_datasets(self):
+    def test_users_cant_edit_other_users_private_datasets(self):
 
         with pytest.raises(toolkit.NotAuthorized):
             call_auth(

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -33,7 +33,6 @@ class TestAuth():
     def test_users_cant_see_other_users_datasets(self):
 
         with pytest.raises(toolkit.NotAuthorized):
-
             call_auth(
                 'package_show',
                 get_context(self.user_1),

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -5,107 +5,122 @@ from ckanext.oht.tests import get_context
 from ckan.plugins import toolkit
 
 
+@pytest.fixture
+def users():
+    return [
+        factories.User(),
+        factories.User()
+    ]
+
+
+@pytest.fixture
+def organisation(request, users):
+
+    return factories.Organization(
+        users=[
+            {'name': users[0]['name'], 'capacity': 'editor'},
+            {'name': users[1]['name'], 'capacity': 'editor'}
+        ]
+    )
+
+
+@pytest.fixture
+def datasets(organisation, users):
+    return [
+        factories.Dataset(
+            owner_org=organisation['id'],
+            type='oht',
+            private=True,
+            user=users[0]
+        ),
+        factories.Dataset(
+            owner_org=organisation['id'],
+            type='oht',
+            private=True,
+            user=users[1]
+        ),
+        factories.Dataset(
+            owner_org=organisation['id'],
+            type='oht',
+            private=False,
+            user=users[1]
+        )
+    ]
+
+
 @pytest.mark.usefixtures("clean_db")
 class TestAuth():
 
-    def setup(self):
-        self.user_1 = factories.User()
-        self.user_2 = factories.User()
-        self.org = factories.Organization(
-            users=[
-                {'name': self.user_1['name'], 'capacity': 'editor'},
-                {'name': self.user_2['name'], 'capacity': 'editor'}
-            ]
-        )
-        self.dataset_1 = factories.Dataset(
-            owner_org=self.org['id'],
-            type='oht',
-            private=True,
-            user=self.user_1
-        )
-        self.dataset_2 = factories.Dataset(
-            owner_org=self.org['id'],
-            type='oht',
-            private=True,
-            user=self.user_2
-        )
-        self.dataset_3 = factories.Dataset(
-            owner_org=self.org['id'],
-            type='oht',
-            private=False,
-            user=self.user_2
-        )
-
-    def test_users_cant_see_other_users_private_datasets(self):
+    def test_users_cant_see_private_datasets(self, users, datasets):
 
         with pytest.raises(toolkit.NotAuthorized):
             call_auth(
                 'package_show',
-                get_context(self.user_1),
-                id=self.dataset_2['id']
+                get_context(users[0]),
+                id=datasets[1]['id']
             )
 
-    def test_users_cant_edit_other_users_private_datasets(self):
+    def test_users_cant_edit_private_datasets(self, users, datasets):
 
         with pytest.raises(toolkit.NotAuthorized):
             call_auth(
                 'package_update',
-                get_context(self.user_1),
-                id=self.dataset_2['id']
+                get_context(users[0]),
+                id=datasets[1]['id']
             )
 
-    def test_users_can_edit_own_datasets(self):
+    def test_users_can_edit_own_datasets(self, users, datasets):
         assert call_auth(
             'package_update',
-            get_context(self.user_1),
-            id=self.dataset_1['id']
+            get_context(users[0]),
+            id=datasets[0]['id']
         )
 
-    def test_users_can_see_own_datasets(self):
+    def test_users_can_see_own_datasets(self, users, datasets):
         assert call_auth(
             'package_show',
-            get_context(self.user_1),
-            id=self.dataset_1['id'],
+            get_context(users[0]),
+            id=datasets[0]['id']
         )
 
-    def test_collaborators_can_see_datasets(self):
+    def test_collaborators_can_see_datasets(self, users, datasets):
         call_action(
             'package_collaborator_create',
-            id=self.dataset_1['id'],
-            user_id=self.user_2['id'],
+            id=datasets[0]['id'],
+            user_id=users[1]['id'],
             capacity='member'
         )
         assert call_auth(
             'package_show',
-            get_context(self.user_2),
-            id=self.dataset_1['id'],
+            get_context(users[1]),
+            id=datasets[0]['id'],
         )
 
-    def test_collaborators_can_edit_datasets(self):
+    def test_collaborators_can_edit_datasets(self, users, datasets):
         call_action(
             'package_collaborator_create',
-            id=self.dataset_2['id'],
-            user_id=self.user_1['id'],
+            id=datasets[0]['id'],
+            user_id=users[1]['id'],
             capacity='editor'
         )
         assert call_auth(
             'package_update',
-            get_context(self.user_1),
-            id=self.dataset_2['id'],
+            get_context(users[1]),
+            id=datasets[0]['id'],
         )
 
-    def test_users_can_see_public_datasets(self):
+    def test_users_can_see_public_datasets(self, users, datasets):
         assert call_auth(
             'package_show',
-            get_context(self.user_1),
-            id=self.dataset_3['id'],
+            get_context(users[0]),
+            id=datasets[2]['id'],
         )
 
-    def test_users_require_permission_to_edit_public_datasets(self):
+    def test_users_cant_edit_public_datasets(self, users, datasets):
 
         with pytest.raises(toolkit.NotAuthorized):
             call_auth(
                 'package_update',
-                get_context(self.user_1),
-                id=self.dataset_3['id']
+                get_context(users[0]),
+                id=datasets[2]['id']
             )

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -5,7 +5,7 @@ from ckanext.oht.tests import get_context
 from ckan.plugins import toolkit
 
 
-@pytest.mark.ckan_config("ckan.plugins", "oht scheming_datasets")
+@pytest.mark.ckan_config("ckan.plugins", "oht")
 @pytest.mark.usefixtures("with_plugins", "clean_db")
 class TestAuth():
 
@@ -22,13 +22,13 @@ class TestAuth():
             owner_org=self.org['id'],
             type='oht',
             private=True,
-            creator_user_id=self.user_1['id']
+            creator_user_id=self.user_1['id'],
         )
         self.dataset_2 = factories.Dataset(
             owner_org=self.org['id'],
             type='oht',
             private=True,
-            creator_user_id=self.user_2['id']
+            creator_user_id=self.user_2['id'],
         )
 
     def test_users_cant_see_other_users_datasets(self):
@@ -48,5 +48,19 @@ class TestAuth():
             )
 
     def test_editors_cant_edit_other_users_datasets(self):
-        # TODO:
-        pass
+
+        with pytest.raises(toolkit.NotAuthorized):
+            call_action(
+                'package_patch',
+                get_context(self.user_1),
+                id=self.dataset_2['id'],
+                title="Changed Title"
+            )
+
+        with pytest.raises(toolkit.NotAuthorized):
+            call_action(
+                'package_patch',
+                get_context(self.user_1),
+                id=self.dataset_2['id'],
+                title="Changed Title"
+            )

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -1,0 +1,51 @@
+import pytest
+from ckan.tests import factories
+from ckan.tests.helpers import call_action
+from ckanext.oht.tests import get_context
+from ckan.plugins import toolkit
+
+
+@pytest.mark.ckan_config("ckan.plugins", "oht scheming_datasets")
+@pytest.mark.usefixtures("with_plugins")
+class TestAuth():
+
+    def setup(self):
+        self.user_1 = factories.User()
+        self.user_2 = factories.User()
+        self.org = factories.Organization(
+            users=[
+                {'name': self.user_1['name'], 'capacity': 'editor'},
+                {'name': self.user_2['name'], 'capacity': 'editor'}
+            ]
+        )
+        self.dataset_1 = factories.Dataset(
+            owner_org=self.org['id'],
+            type='oht',
+            private=True,
+            creator_user_id=self.user_1['id']
+        )
+        self.dataset_2 = factories.Dataset(
+            owner_org=self.org['id'],
+            type='oht',
+            private=True,
+            creator_user_id=self.user_2['id']
+        )
+
+    def test_users_cant_see_other_users_datasets(self):
+        with pytest.raises(toolkit.NotAuthorized):
+            call_action(
+                'package_show',
+                get_context(self.user_1),
+                id=self.dataset_2['id']
+            )
+
+        with pytest.raises(toolkit.NotAuthorized):
+            call_action(
+                'package_show',
+                get_context(self.user_2),
+                id=self.dataset_1['id']
+            )
+
+    def test_editors_cant_edit_other_users_datasets(self):
+        # TODO:
+        pass

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -5,7 +5,7 @@ from ckanext.oht.tests import get_context
 from ckan.plugins import toolkit
 
 
-@pytest.mark.usefixtures("with_plugins", "clean_db")
+@pytest.mark.usefixtures("clean_db")
 class TestAuth():
 
     def setup(self):

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -45,21 +45,7 @@ class TestAuth():
                 id=self.dataset_2['id']
             )
 
-        with pytest.raises(toolkit.NotAuthorized):
-            call_auth(
-                'package_show',
-                get_context(self.user_2),
-                id=self.dataset_1['id']
-            )
-
     def test_users_cant_edit_other_users_private_datasets(self):
-
-        with pytest.raises(toolkit.NotAuthorized):
-            call_auth(
-                'package_update',
-                get_context(self.user_1),
-                id=self.dataset_2['id']
-            )
 
         with pytest.raises(toolkit.NotAuthorized):
             call_auth(
@@ -74,22 +60,12 @@ class TestAuth():
             get_context(self.user_1),
             id=self.dataset_1['id']
         )
-        assert call_auth(
-            'package_update',
-            get_context(self.user_2),
-            id=self.dataset_2['id']
-        )
 
     def test_users_can_see_own_datasets(self):
         assert call_auth(
             'package_show',
             get_context(self.user_1),
             id=self.dataset_1['id'],
-        )
-        assert call_auth(
-            'package_show',
-            get_context(self.user_2),
-            id=self.dataset_2['id'],
         )
 
     def test_collaborators_can_see_datasets(self):
@@ -126,6 +102,7 @@ class TestAuth():
         )
 
     def test_users_require_permission_to_edit_public_datasets(self):
+
         with pytest.raises(toolkit.NotAuthorized):
             call_auth(
                 'package_update',

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -6,7 +6,7 @@ from ckan.plugins import toolkit
 
 
 @pytest.mark.ckan_config("ckan.plugins", "oht scheming_datasets")
-@pytest.mark.usefixtures("with_plugins")
+@pytest.mark.usefixtures("with_plugins", "clean_db")
 class TestAuth():
 
     def setup(self):
@@ -33,6 +33,7 @@ class TestAuth():
 
     def test_users_cant_see_other_users_datasets(self):
         with pytest.raises(toolkit.NotAuthorized):
+
             call_action(
                 'package_show',
                 get_context(self.user_1),

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -13,13 +13,13 @@ def users():
     ]
 
 
-@pytest.fixture
+@pytest.fixture(params=["editor", "admin"])
 def organisation(request, users):
 
     return factories.Organization(
         users=[
-            {'name': users[0]['name'], 'capacity': 'editor'},
-            {'name': users[1]['name'], 'capacity': 'editor'}
+            {'name': users[0]['name'], 'capacity': request.param},
+            {'name': users[1]['name'], 'capacity': request.param}
         ]
     )
 

--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -29,6 +29,12 @@ class TestAuth():
             private=True,
             user=self.user_2
         )
+        self.dataset_3 = factories.Dataset(
+            owner_org=self.org['id'],
+            type='oht',
+            private=False,
+            user=self.user_2
+        )
 
     def test_users_cant_see_other_users_datasets(self):
 
@@ -111,3 +117,18 @@ class TestAuth():
             get_context(self.user_1),
             id=self.dataset_2['id'],
         )
+
+    def test_users_can_see_public_datasets(self):
+        assert call_auth(
+            'package_show',
+            get_context(self.user_1),
+            id=self.dataset_3['id'],
+        )
+
+    def test_users_require_permission_to_edit_public_datasets(self):
+        with pytest.raises(toolkit.NotAuthorized):
+            call_auth(
+                'package_update',
+                get_context(self.user_1),
+                id=self.dataset_3['id']
+            )

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ use = config:../ckan/test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
 ckan.plugins = oht
-
+ckan.auth.allow_dataset_collaborators = true
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
This PR makes some small alterations to CKAN permissions so that datasets are hidden from members of the same organisation.  

The idea is:

- Being a member of the same organisation as the dataset's owner org does not entitle you to view the dataset. 
- Being an editor/admin of the same organisation as the dataset's owner org does not entitle you to edit the dataset. 
- Datasets can only be viewed if the user is a collaborator on that dataset, or the dataset creator, or the dataset is public. 
- Datasets can only be edited if the user is an editor/admin collaborator on the dataset, or the dataset creator.

To this end I have implemented the IPermissionLabels interface, and removed the label "member-<org_id>" from each dataset, meaning that for the purposes of establishing read_permissions the dataset is no longer part of its parent organisation, and members of that organisation will therefore not be able to view the dataset.  I have not bench-marked my changes yet as I do not have access to lots of demo data. However I believe the use of IPermissionLabels interface is an excellent way of ensuring that solr searches remain super fast (because the labels are used in the solr index).  

The auth function for package_update was not so elegant as package_show.  This is frustrating. I first considered "chaining" a little check that the user can view the package (using the new logic) to the default auth function.  This however did not work for public packages which could be seen by others, but should not be edited by others. 

What is proposed in this PR (for further discussion) is a very explicit and simple auth check that only allows package_update if the user is the dataset creator or an editor/admin collaborator. This is what we want for OHT I believe, and we have no intention of using groups or allowing for other settings such as anonymous dataset editing.  

Automated tests are included, and the change has also been manually tested in the UI. It is likely that some further discussion should happen in person about this work, and whether we can see any better alternative approaches. 