### PR TITLE
OHT-41 Permissions to manage collaborators

### DIFF
--- a/ckanext/oht/tests/test_auth.py
+++ b/ckanext/oht/tests/test_auth.py
@@ -124,3 +124,33 @@ class TestAuth():
                 get_context(users[0]),
                 id=datasets[2]['id']
             )
+
+    def test_creator_can_list_collaborators(self, users, datasets):
+        assert call_auth(
+            'package_collaborator_list',
+            get_context(users[0]),
+            id=datasets[0]['id']
+        )
+
+    def test_creator_can_add_collaborators(self, users, datasets):
+        assert call_auth(
+            'package_collaborator_create',
+            get_context(users[0]),
+            id=datasets[0]['id'],
+            user_id=users[1]['id'],
+            capacity='editor'
+        )
+
+    def test_creator_can_delete_collaborators(self, users, datasets):
+        call_action(
+            'package_collaborator_create',
+            id=datasets[0]['id'],
+            user_id=users[1]['id'],
+            capacity='editor'
+        )
+        assert call_auth(
+            'package_collaborator_delete',
+            get_context(users[0]),
+            id=datasets[0]['id'],
+            user_id=users[1]['id']
+        )


### PR DESCRIPTION
At the moment permission to manage collaborators is determined by the function `ckan.authz.can_manage_collaborators`. 

This function determines that in our case only “Admin” users of the dataset owner org can edit collaborators.  We wanted all of our users to be editors of the single master org.  The frustrating thing is that there is no easy way of overriding this authz function from a plugin. 

The best solution I could come up with was to explicitly ensure that creators of datasets can always edit collaborators, then after checking this to default to the existing core auth logic.  This is done through a chained auth function based on the design of existing auth functions. 