### PR TITLE
OHT-55 Private dataset activities

### DIFF
--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -85,17 +85,12 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
             'package_collaborator_list': oht_authz.creators_can_manage_collaborators
         }
 
+    # IPackageContoller
     def after_update(self, context, data_dict):
         if data_dict.get('private'):
-            _add_activity(context, data_dict, "changed")
+            oht_upload.add_activity(context, data_dict, "changed")
 
     def after_create(self, context, data_dict):
         if data_dict.get('private'):
-            _add_activity(context, data_dict, "new")
+            oht_upload.add_activity(context, data_dict, "new")
 
-
-def _add_activity(context, data_dict, activity_type):
-    user_id = context['model'].User.by_name(context['user']).id
-    package = context.get("package", context['model'].Package.get(data_dict["name"]))
-    activity = package.activity_stream_item(activity_type, user_id)
-    context['session'].add(activity)

--- a/ckanext/oht/upload.py
+++ b/ckanext/oht/upload.py
@@ -9,6 +9,13 @@ import ckan.plugins.toolkit as toolkit
 log = logging.getLogger(__name__)
 
 
+def add_activity(context, data_dict, activity_type):
+    user_id = context['model'].User.by_name(context['user']).id
+    package = context.get("package", context['model'].Package.get(data_dict["name"]))
+    activity = package.activity_stream_item(activity_type, user_id)
+    context['session'].add(activity)
+
+
 def handle_giftless_uploads(context, resource, current=None):
     if _data_dict_is_resource(resource):
         _giftless_upload(context, resource, current=current)
@@ -85,3 +92,4 @@ def _get_upload_authz_token(context, dataset_name, org_name):
         log.error(error)
         raise toolkit.NotAuthorized(error)
     return authz_result['token']
+


### PR DESCRIPTION
Another one for discussion.

By default [CKAN does not generate dataset activities for private datasets](https://github.com/ckan/ckan/issues/5772). 

The reason for this is that the core devs believe it should be possible for private dataset activities to be kept private. No-one has yet implemented the auth logic for this, so they escape the whole issue by not generating any activities at all whilst the dataset is in private mode.

However...

In our specific cases I believe it is fine that when a dataset is made public, the audit trail for that dataset is also made public. In fact I believe there are many good things about transparent audit trails, and plenty of reasons why it should be done this way.  We can further discuss and confirm this with Avenir.

This PR proposes a means to generate activity streams whilst the dataset is private.  I have tested the feature manually and written some automated tests as well. Activity streams are only accessible if the user has access to view the dataset. Activities are generated whether or not the dataset is public or private. This ensures that the activity stream is complete and not partial. 

This PR is of a lower priority than other PRs. 

--
It is worth noting that there are some big changes to the way activities are handled already made to core ckan master branch.   This change will need to be reviewed at some point when updating ckan core. If in doubt, I figure it is better to collect the data, than not collect the data.    