### PR TITLE
OHT-62 Fix organisation page bug

### DIFF
--- a/ckanext/oht/templates/organization/read.html
+++ b/ckanext/oht/templates/organization/read.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block page_primary_action %}
+{# Hide the add dataset selector from the organisation page #}
+{% endblock %}

--- a/ckanext/oht/templates/snippets/add_dataset.html
+++ b/ckanext/oht/templates/snippets/add_dataset.html
@@ -6,7 +6,7 @@
 {% set dataset_link_name = schema.link_name if schema.link_name else dataset_name %}
 
 {% if group %}
-    {% link_for _('General Data'), controller='package', action='new', group=group, class_='dropdown-item'%}
+    {% link_for _('General Data'), named_route='dataset.new', group=group, class_='dropdown-item' %}
 {% else %}
-    {% link_for _(dataset_link_name), controller='package', action='new', named_route=dataset_type + '_new', class_='dropdown-item' %}
+    {% link_for _(dataset_link_name), named_route=dataset_type ~ '.new', class_='dropdown-item' %}
 {% endif %}


### PR DESCRIPTION
The "Add Dataset" button was breaking for the organisation page.  The simplest fix, especially given we are not using organisations in OHT, was just to remove the button from the organisation page.   