### PR TITLE
OHT-63 Autogenerate passwords

### DIFF
--- a/ckanext/oht/actions.py
+++ b/ckanext/oht/actions.py
@@ -1,0 +1,14 @@
+import ckan.plugins.toolkit as toolkit
+import secrets
+
+
+@toolkit.chained_action
+def user_create(next_action, context, data_dict):
+    """
+    Autogenerates a password (if password is not provided).
+    """
+
+    if not data_dict.get('password'):
+        data_dict['password'] = secrets.token_urlsafe(32)
+
+    return next_action(context, data_dict)

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -12,7 +12,7 @@ from ckanext.oht.helpers import (
 import ckanext.oht.authz as oht_authz
 import ckanext.oht.authn as oht_authn
 import ckanext.oht.upload as oht_upload
-from flask import abort, jsonify
+import ckanext.oht.actions as oht_actions
 
 
 log = logging.getLogger(__name__)
@@ -26,6 +26,7 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     plugins.implements(plugins.IResourceController, inherit=True)
     plugins.implements(plugins.IPermissionLabels)
     plugins.implements(plugins.IAuthFunctions)
+    plugins.implements(plugins.IActions)
     plugins.implements(plugins.IPackageController, inherit=True)
     plugins.implements(plugins.IAuthenticator, inherit=True)
 
@@ -87,6 +88,12 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
             'package_collaborator_create': oht_authz.creators_can_manage_collaborators,
             'package_collaborator_delete': oht_authz.creators_can_manage_collaborators,
             'package_collaborator_list': oht_authz.creators_can_manage_collaborators
+        }
+
+    # IActions
+    def get_actions(self):
+        return {
+            'user_create': oht_actions.user_create
         }
 
     # IPackageContoller

--- a/ckanext/oht/tests/test_actions.py
+++ b/ckanext/oht/tests/test_actions.py
@@ -1,46 +1,67 @@
 import pytest
 import mock
+from zxcvbn import zxcvbn
 from ckan.tests.helpers import call_action
+from ckanext.oht.actions import user_create
+import ckan.tests.factories as factories
+from ckanext.oht.tests import get_context
 
 
-@pytest.fixture
-def mock_encrypt():
-    dummy_hashed_password = (
-        '$pbkdf2-sha512$25000$ZsyZs1bqfe.d07qXsvZeyw$G7VBEvwdL'
-        'rzhZB0/8/w89XvzXDCF1PPcz7agyExrQnBKbbFN9qK8Z6OH0eNhUc'
-        'a2yHfowYbYQyBV5lAe0PcNBg'
-    )
-    with mock.patch('ckan.model.user.pbkdf2_sha512.encrypt',
-                    return_value=dummy_hashed_password) as mock_encrypt:
-        yield mock_encrypt
+DUMMY_PASSWORD = '01234567890123456789012345678901'
 
 
 @pytest.fixture
 def mock_token_urlsafe():
-    dummy_token = '01234567890123456789012345678901'
     with mock.patch('ckanext.oht.actions.secrets.token_urlsafe',
-                    return_value=dummy_token) as mock_token_urlsafe:
+                    return_value=DUMMY_PASSWORD) as mock_token_urlsafe:
         yield mock_token_urlsafe
 
 
 @pytest.mark.usefixtures('clean_db', 'with_plugins')
 class TestCreateUser():
 
-    def test_with_password(self, mock_encrypt, mock_token_urlsafe):
-        call_action(
-            'user_create',
-            name='test_user',
-            email='test@test.org',
-            password='password'
-        )
-        mock_token_urlsafe.assert_not_called()
-        mock_encrypt.assert_called_once_with('password')
+    def test_unit_with_password(self, mock_token_urlsafe):
+        next_action = mock.Mock()
+        data_dict = {
+            'name': 'test_user',
+            'email': 'test@test.org',
+            'password': 'password'
+        }
+        user_create(next_action, {}, data_dict)
+        next_action.assert_called_once_with({}, data_dict)
 
-    def test_with_no_password(self, mock_encrypt, mock_token_urlsafe):
+    def test_unit_without_password(self, mock_token_urlsafe):
+        next_action = mock.Mock()
+        data_dict = {
+            'name': 'test_user',
+            'email': 'test@test.org'
+        }
+        user_create(next_action, {}, data_dict)
+        expected_data_dict = {**data_dict, 'password': DUMMY_PASSWORD}
+        next_action.assert_called_once_with({}, expected_data_dict)
+
+    def test_auto_generated_password_is_strong(self):
+        next_action = mock.Mock()
+        data_dict = {
+            'name': 'test_user',
+            'email': 'test@test.org'
+        }
+        user_create(next_action, {}, data_dict)
+        generated_password = next_action.call_args[0][1]['password']
+        assert len(generated_password) > 30
+        zxcvbn(generated_password)['score'] == 4
+
+    def test_integration_without_password(self):
         call_action(
             'user_create',
             name='test_user',
             email='test@test.org'
         )
-        mock_token_urlsafe.assert_called_once_with(32)
-        mock_encrypt.assert_called_once_with('01234567890123456789012345678901')
+        sysadmin = factories.User(sysadmin=True)
+        response = call_action(
+            'user_show',
+            get_context(sysadmin['name']),
+            id='test_user',
+            include_password_hash=True
+        )
+        assert response['password_hash']

--- a/ckanext/oht/tests/test_actions.py
+++ b/ckanext/oht/tests/test_actions.py
@@ -49,7 +49,7 @@ class TestCreateUser():
         user_create(next_action, {}, data_dict)
         generated_password = next_action.call_args[0][1]['password']
         assert len(generated_password) > 30
-        zxcvbn(generated_password)['score'] == 4
+        assert zxcvbn(generated_password)['score'] == 4
 
     def test_integration_without_password(self):
         call_action(

--- a/ckanext/oht/tests/test_actions.py
+++ b/ckanext/oht/tests/test_actions.py
@@ -1,0 +1,46 @@
+import pytest
+import mock
+from ckan.tests.helpers import call_action
+
+
+@pytest.fixture
+def mock_encrypt():
+    dummy_hashed_password = (
+        '$pbkdf2-sha512$25000$ZsyZs1bqfe.d07qXsvZeyw$G7VBEvwdL'
+        'rzhZB0/8/w89XvzXDCF1PPcz7agyExrQnBKbbFN9qK8Z6OH0eNhUc'
+        'a2yHfowYbYQyBV5lAe0PcNBg'
+    )
+    with mock.patch('ckan.model.user.pbkdf2_sha512.encrypt',
+                    return_value=dummy_hashed_password) as mock_encrypt:
+        yield mock_encrypt
+
+
+@pytest.fixture
+def mock_token_urlsafe():
+    dummy_token = '01234567890123456789012345678901'
+    with mock.patch('ckanext.oht.actions.secrets.token_urlsafe',
+                    return_value=dummy_token) as mock_token_urlsafe:
+        yield mock_token_urlsafe
+
+
+@pytest.mark.usefixtures('clean_db', 'with_plugins')
+class TestCreateUser():
+
+    def test_with_password(self, mock_encrypt, mock_token_urlsafe):
+        call_action(
+            'user_create',
+            name='test_user',
+            email='test@test.org',
+            password='password'
+        )
+        mock_token_urlsafe.assert_not_called()
+        mock_encrypt.assert_called_once_with('password')
+
+    def test_with_no_password(self, mock_encrypt, mock_token_urlsafe):
+        call_action(
+            'user_create',
+            name='test_user',
+            email='test@test.org'
+        )
+        mock_token_urlsafe.assert_called_once_with(32)
+        mock_encrypt.assert_called_once_with('01234567890123456789012345678901')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 pytest-ckan
+zxcvbn


### PR DESCRIPTION
We want to be able to create accounts without having specify a password field. 

This PR uses the Python secrets library to auto-generate a 32 character crypto-secure string for use as the user's password. 

Testing is always a bit tricky when it comes to passwords, since they are hashed.  I have mocked out the hashing algorithm during user creation in order to check that the expected auto-generated passwords are being used. 

Goes hand in hand with PR https://github.com/fjelltopp/ckanext-oht/pull/25