### PR TITLE
OHT-64 Only allow sysadmin access

### DIFF
--- a/ckanext/oht/authn.py
+++ b/ckanext/oht/authn.py
@@ -4,20 +4,6 @@ import ckan.plugins.toolkit as toolkit
 
 
 def substitute_user(substitute_user_id):
-    # Not ideal, but this private import is the only way to use core CKAN logic.
-    _identify_user_default()
-    sysadmin = toolkit.g.userobj and toolkit.g.userobj.sysadmin
-
-    if not sysadmin:
-        return {
-            "success": False,
-            "error": {
-                "__type": "Not Authorized",
-                "message": "User not authorized to send requests "
-                           "with CKAN-Substitute-User header"
-            }
-        }, 403
-
     substitute_user_obj = model.User.get(substitute_user_id)
 
     if not substitute_user_obj:
@@ -32,3 +18,10 @@ def substitute_user(substitute_user_id):
 
     toolkit.g.user = substitute_user_id
     toolkit.g.userobj = substitute_user_obj
+
+
+def is_sysadmin():
+    # Not ideal, but this private import is the only way to use core CKAN logic.
+    _identify_user_default()
+    sysadmin = toolkit.g.userobj and toolkit.g.userobj.sysadmin
+    return bool(sysadmin)

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -12,6 +12,7 @@ from ckanext.oht.helpers import (
 import ckanext.oht.authz as oht_authz
 import ckanext.oht.authn as oht_authn
 import ckanext.oht.upload as oht_upload
+from flask import abort, jsonify
 
 
 log = logging.getLogger(__name__)
@@ -104,6 +105,16 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         done by setting a HTTP Header in the requests "CKAN-Substitute-User" to be the
         username or user id of another CKAN user.
         """
+
+        if not oht_authn.is_sysadmin():
+            return {
+                "success": False,
+                "error": {
+                    "__type": "Not Authorized",
+                    "message": "Must be a system administrator to perform this action."
+                }
+            }, 403
+
         substitute_user_id = toolkit.request.headers.get('CKAN-Substitute-User')
 
         if substitute_user_id:


### PR DESCRIPTION
This PR shuts off the system to everyone except for sysadmins. This goes hand in hand with [PR#24 ](https://github.com/fjelltopp/ckanext-oht/pull/24) which introduces auto-generation of passwords.