### PR TITLE
OHT-65 Autogenerate dataset names

### DIFF
--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -13,7 +13,7 @@ import ckanext.oht.authz as oht_authz
 import ckanext.oht.authn as oht_authn
 import ckanext.oht.upload as oht_upload
 import ckanext.oht.actions as oht_actions
-
+import ckanext.oht.validators as oht_validators
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +27,7 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     plugins.implements(plugins.IPermissionLabels)
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IValidators)
     plugins.implements(plugins.IPackageController, inherit=True)
     plugins.implements(plugins.IAuthenticator, inherit=True)
 
@@ -94,6 +95,12 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     def get_actions(self):
         return {
             'user_create': oht_actions.user_create
+        }
+
+    # IValidators
+    def get_validators(self):
+        return {
+            'auto_generate_name_from_title': oht_validators.auto_generate_name_from_title
         }
 
     # IPackageContoller

--- a/ckanext/oht/schemas/oht.yaml
+++ b/ckanext/oht/schemas/oht.yaml
@@ -16,7 +16,7 @@ dataset_fields:
 - field_name: name
   label: URL
   validators: auto_generate_name_from_title unicode_safe name_validator package_name_validator
-  form_snippet: slug.html
+  preset: dataset_slug
   form_placeholder: eg. my-dataset
 
 - field_name: first_year

--- a/ckanext/oht/schemas/oht.yaml
+++ b/ckanext/oht/schemas/oht.yaml
@@ -14,7 +14,8 @@ dataset_fields:
 
 - field_name: name
   label: URL
-  preset: dataset_slug
+  validators: auto_generate_name_from_title unicode_safe name_validator package_name_validator
+  form_snippet: slug.html
   form_placeholder: eg. my-dataset
 
 - field_name: first_year

--- a/ckanext/oht/schemas/oht.yaml
+++ b/ckanext/oht/schemas/oht.yaml
@@ -11,6 +11,7 @@ dataset_fields:
   label: Projection Title
   preset: title
   form_placeholder: eg. A descriptive filename
+  validators: not_empty unicode_safe
 
 - field_name: name
   label: URL

--- a/ckanext/oht/tests/schemas/auto_generate_name_from_title.yaml
+++ b/ckanext/oht/tests/schemas/auto_generate_name_from_title.yaml
@@ -1,0 +1,24 @@
+scheming_version: 2
+dataset_type: auto-generate-name-from-title
+name: Auto Generate NAme From Title
+about: A test schema to test the validator auto_generate_name_from_title
+about_url: http://github.com/ckan/ckanext-scheming
+
+
+dataset_fields:
+
+- field_name: title
+  label: Projection Title
+  preset: title
+  form_placeholder: eg. A descriptive filename
+
+- field_name: name
+  label: URL
+  validators: auto_generate_name_from_title unicode_safe name_validator package_name_validator
+  form_snippet: slug.html
+  form_placeholder: eg. my-dataset
+
+resource_fields:
+
+- field_name: name
+  label: Name

--- a/ckanext/oht/tests/schemas/auto_generate_name_from_title.yaml
+++ b/ckanext/oht/tests/schemas/auto_generate_name_from_title.yaml
@@ -16,7 +16,7 @@ dataset_fields:
 - field_name: name
   label: URL
   validators: auto_generate_name_from_title unicode_safe name_validator package_name_validator
-  form_snippet: slug.html
+  preset: dataset_slug
   form_placeholder: eg. my-dataset
 
 resource_fields:

--- a/ckanext/oht/tests/schemas/auto_generate_name_from_title.yaml
+++ b/ckanext/oht/tests/schemas/auto_generate_name_from_title.yaml
@@ -11,6 +11,7 @@ dataset_fields:
   label: Projection Title
   preset: title
   form_placeholder: eg. A descriptive filename
+  validators: not_empty unicode_safe
 
 - field_name: name
   label: URL

--- a/ckanext/oht/tests/test_validators.py
+++ b/ckanext/oht/tests/test_validators.py
@@ -1,0 +1,56 @@
+import pytest
+import mock
+from ckan.tests.helpers import call_action
+from ckan.plugins.toolkit import ValidationError
+
+
+def create_dataset(dataset_title="North Pole Projection", **kwargs):
+    return call_action(
+        "package_create",
+        type="auto-generate-name-from-title",
+        title=dataset_title,
+        **kwargs
+    )
+
+
+@pytest.mark.ckan_config("ckan.plugins", "oht scheming_datasets")
+@pytest.mark.usefixtures("clean_db", "clean_index", "with_plugins")
+class TestAutoGenerateNameFromTitle(object):
+
+    def test_name_is_slugified_title(self):
+        dataset = create_dataset()
+        assert dataset["name"] == "north-pole-projection"
+
+    def test_duplicate_titles(self):
+        datasets = [create_dataset() for i in range(10)]
+        for dataset in datasets:
+            assert dataset["name"].startswith("north-pole-projection")
+
+    def test_preserves_given_name(self):
+        dataset = create_dataset(name="test-name")
+        assert dataset["name"] == "test-name"
+
+    def test_error_raised_if_given_name_exists(self):
+        dataset = create_dataset()
+        with pytest.raises(ValidationError, match="URL is already in use"):
+            create_dataset(name=dataset["name"])
+
+    def test_preserves_existing_dataset_name(self):
+        dataset1, dataset2 = [create_dataset() for i in range(2)]
+        call_action("package_delete", id=dataset1["id"])
+        updated_dataset2 = call_action("package_update", **dataset2)
+        assert updated_dataset2["name"] == dataset2["name"]
+
+    def test_handles_deleted_datasets(self):
+        dataset1, dataset2 = [create_dataset() for i in range(2)]
+        call_action("package_delete", id=dataset2["id"])
+        dataset3 = create_dataset(name=dataset2["name"])
+        assert dataset3["name"] == dataset2["name"]
+
+    @mock.patch("ckanext.oht.validators.choice", return_value="a")
+    def test_many_failed_generation_attempts(self, mock_choice):
+        create_dataset()
+        create_dataset()
+        with pytest.raises(ValidationError, match="Could not autogenerate"):
+            create_dataset()
+

--- a/ckanext/oht/tests/test_validators.py
+++ b/ckanext/oht/tests/test_validators.py
@@ -4,11 +4,11 @@ from ckan.tests.helpers import call_action
 from ckan.plugins.toolkit import ValidationError
 
 
-def create_dataset(dataset_title="North Pole Projection", **kwargs):
+def create_dataset(**kwargs):
     return call_action(
         "package_create",
         type="auto-generate-name-from-title",
-        title=dataset_title,
+        title="North Pole Projection",
         **kwargs
     )
 

--- a/ckanext/oht/tests/test_validators.py
+++ b/ckanext/oht/tests/test_validators.py
@@ -4,55 +4,54 @@ from ckan.tests.helpers import call_action
 from ckan.plugins.toolkit import ValidationError
 
 
-def create_dataset(**kwargs):
-    return call_action(
-        "package_create",
-        type="auto-generate-name-from-title",
-        title="North Pole Projection",
-        **kwargs
-    )
-
-
 @pytest.mark.ckan_config("ckan.plugins", "oht scheming_datasets")
 @pytest.mark.usefixtures("clean_db", "clean_index", "with_plugins")
 class TestAutoGenerateNameFromTitle(object):
 
+    def _create_dataset(self, **kwargs):
+        return call_action(
+            "package_create",
+            type="auto-generate-name-from-title",
+            title="North Pole Projection",
+            **kwargs
+        )
+
     def test_name_is_slugified_title(self):
-        dataset = create_dataset()
+        dataset = self._create_dataset()
         assert dataset["name"] == "north-pole-projection"
 
     def test_duplicate_titles(self):
-        datasets = [create_dataset() for i in range(10)]
+        datasets = [self._create_dataset() for i in range(10)]
         for dataset in datasets:
             assert dataset["name"].startswith("north-pole-projection")
 
     def test_preserves_given_name(self):
-        dataset = create_dataset(name="test-name")
+        dataset = self._create_dataset(name="test-name")
         assert dataset["name"] == "test-name"
 
     def test_error_raised_if_given_name_exists(self):
-        dataset = create_dataset()
+        dataset = self._create_dataset()
         with pytest.raises(ValidationError, match="URL is already in use"):
-            create_dataset(name=dataset["name"])
+            self._create_dataset(name=dataset["name"])
 
     def test_preserves_existing_dataset_name(self):
-        dataset1, dataset2 = [create_dataset() for i in range(2)]
+        dataset1, dataset2 = [self._create_dataset() for i in range(2)]
         call_action("package_delete", id=dataset1["id"])
         updated_dataset2 = call_action("package_update", **dataset2)
         assert updated_dataset2["name"] == dataset2["name"]
 
     def test_handles_deleted_datasets(self):
-        dataset1, dataset2 = [create_dataset() for i in range(2)]
+        dataset1, dataset2 = [self._create_dataset() for i in range(2)]
         call_action("package_delete", id=dataset2["id"])
-        dataset3 = create_dataset(name=dataset2["name"])
+        dataset3 = self._create_dataset(name=dataset2["name"])
         assert dataset3["name"] == dataset2["name"]
 
     @mock.patch("ckanext.oht.validators.choice", return_value="a")
     def test_many_failed_generation_attempts(self, mock_choice):
-        create_dataset()
-        create_dataset()
+        self._create_dataset()
+        self._create_dataset()
         with pytest.raises(ValidationError, match="Could not autogenerate"):
-            create_dataset()
+            self._create_dataset()
 
     def test_missing_title(self):
         with pytest.raises(ValidationError, match="title.*Missing value"):

--- a/ckanext/oht/tests/test_validators.py
+++ b/ckanext/oht/tests/test_validators.py
@@ -54,3 +54,6 @@ class TestAutoGenerateNameFromTitle(object):
         with pytest.raises(ValidationError, match="Could not autogenerate"):
             create_dataset()
 
+    def test_missing_title(self):
+        with pytest.raises(ValidationError, match="title.*Missing value"):
+            call_action("package_create", type="auto-generate-name-from-title")

--- a/ckanext/oht/validators.py
+++ b/ckanext/oht/validators.py
@@ -1,0 +1,38 @@
+from ckanext.scheming.validation import scheming_validator
+from ckan.logic.validators import package_name_validator
+from ckan.plugins.toolkit import ValidationError, _
+from string import ascii_lowercase
+from random import choice
+import copy
+import slugify
+
+
+@scheming_validator
+def auto_generate_name_from_title(field, schema):
+    def validator(key, data, errors, context):
+
+        if context.get('package'):  # Editing an existing package
+            data[key] = context['package'].name
+            return
+
+        if data[key]:
+            return
+
+        title_slug = slugify.slugify(data[('title',)])
+        data[key] = title_slug
+
+        for counter in range(10):
+            package_name_errors = copy.deepcopy(errors)
+            package_name_validator(key, data, package_name_errors, context)
+
+            if package_name_errors[key] == errors[key]:
+                break
+
+            else:
+                alpha_id = ''.join(choice(ascii_lowercase) for i in range(3))
+                data[key] = "{}-{}".format(title_slug, alpha_id)
+
+        else:  # If we fail after 10 attempts, somthing is wrong
+            raise ValidationError({'name': [_('Could not autogenerate a unique name.')]})
+
+    return validator

--- a/ckanext/oht/validators.py
+++ b/ckanext/oht/validators.py
@@ -15,8 +15,11 @@ def auto_generate_name_from_title(field, schema):
             data[key] = context['package'].name
             return
 
-        if data[key]:
+        if data[key]:  # Use the exact name given by the user
             return
+
+        if not data[('title',)]:  # No title means we can't proceed
+            raise ValidationError({'title': ['Missing value']})
 
         title_slug = slugify.slugify(data[('title',)])
         data[key] = title_slug

--- a/ckanext/oht/validators.py
+++ b/ckanext/oht/validators.py
@@ -12,21 +12,22 @@ def auto_generate_name_from_title(field, schema):
 
     def validator(key, data, errors, context):
 
-        if context.get('package'):  # Editing an existing package
+        # Preserve the name when editing an existing package
+        if context.get('package'):
             data[key] = context['package'].name
             return
 
-        if data[key]:  # Use the exact name given by the user
+        # Use the exact name given by the user if it exists
+        if data[key]:
             return
 
-        if not data[('title',)]:  # No title means we can't proceed
+        if not data[('title',)]:
             raise ValidationError({'title': ['Missing value']})
 
         title_slug = slugify.slugify(data[('title',)])
         data[key] = title_slug
 
-        # Multiple attempts to keep alpha_id as short as possible
-        # < 1e-42 chance that 10 attempts fail with 1000 duplicate titles
+        # Multiple attempts so alpha_id can be as short as possible
         for counter in range(10):
             package_name_errors = copy.deepcopy(errors)
             package_name_validator(key, data, package_name_errors, context)

--- a/test.ini
+++ b/test.ini
@@ -11,6 +11,8 @@ use = config:../ckan/test-core.ini
 ckan.plugins = oht
 ckan.auth.allow_dataset_collaborators = true
 
+scheming.dataset_schemas = ckanext.oht.tests.schemas:auto_generate_name_from_title.yaml
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy


### PR DESCRIPTION
Avenir does not want to have to generate unique url-friendly dataset names on their side.  He has asked that the dataset name be auto-generated from the given title.  We have done something similar already in ADR, so this is a port of that feature to OHT. 

The scheming plugin can't be used to scheme users, which is why we have been hooking in to the action to auto-generate fields there.  But for datasets we can use scheming validators to auto-generate fields.  This is a more flexible approach, allowing us to treat different types of datasets differently. 

 