### PR TITLE
OHT-64 Grant unregistered users access to public pages

### DIFF
--- a/ckanext/oht/authn.py
+++ b/ckanext/oht/authn.py
@@ -1,5 +1,4 @@
 import ckan.model as model
-from ckan.views import _identify_user_default
 import ckan.plugins.toolkit as toolkit
 
 
@@ -18,10 +17,3 @@ def substitute_user(substitute_user_id):
 
     toolkit.g.user = substitute_user_id
     toolkit.g.userobj = substitute_user_obj
-
-
-def is_sysadmin():
-    # Not ideal, but this private import is the only way to use core CKAN logic.
-    _identify_user_default()
-    sysadmin = toolkit.g.userobj and toolkit.g.userobj.sysadmin
-    return bool(sysadmin)

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -133,7 +133,7 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
                     "success": False,
                     "error": {
                         "__type": "Not Authorized",
-                        "message": "Must be a system administrator to perform this action."
+                        "message": "Must be a system administrator."
                     }
                 }, 403
 

--- a/ckanext/oht/plugin.py
+++ b/ckanext/oht/plugin.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader
+from ckan.views import _identify_user_default
 import ckanext.blob_storage.helpers as blobstorage_helpers
 from ckan.lib.plugins import DefaultPermissionLabels
 
@@ -14,6 +15,7 @@ import ckanext.oht.authn as oht_authn
 import ckanext.oht.upload as oht_upload
 import ckanext.oht.actions as oht_actions
 import ckanext.oht.validators as oht_validators
+
 
 log = logging.getLogger(__name__)
 
@@ -120,16 +122,22 @@ class OHTPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         username or user id of another CKAN user.
         """
 
-        if not oht_authn.is_sysadmin():
-            return {
-                "success": False,
-                "error": {
-                    "__type": "Not Authorized",
-                    "message": "Must be a system administrator to perform this action."
-                }
-            }, 403
+        # Not ideal, but this private import is the only way to use core CKAN logic.
+        _identify_user_default()
 
-        substitute_user_id = toolkit.request.headers.get('CKAN-Substitute-User')
+        if toolkit.g.userobj:
 
-        if substitute_user_id:
-            return oht_authn.substitute_user(substitute_user_id)
+            if not toolkit.g.userobj.sysadmin:
+
+                return {
+                    "success": False,
+                    "error": {
+                        "__type": "Not Authorized",
+                        "message": "Must be a system administrator to perform this action."
+                    }
+                }, 403
+
+            substitute_user_id = toolkit.request.headers.get('CKAN-Substitute-User')
+
+            if substitute_user_id:
+                return oht_authn.substitute_user(substitute_user_id)

--- a/ckanext/oht/tests/test_authn.py
+++ b/ckanext/oht/tests/test_authn.py
@@ -6,18 +6,10 @@ from ckan.tests import factories
 @pytest.mark.usefixtures("clean_db")
 class TestSysadminsOnlyCanAccessAPI():
 
-    def test_error_raised_for_unregistered_user(self, app):
-        response = app.get(
-            toolkit.url_for('api.action', ver=3, logic_function='package_list')
-        )
-        assert response.status_code == 403
-        assert response.json == {
-            'success': False,
-            'error': {
-                '__type': 'Not Authorized',
-                'message': "Must be a system administrator to perform this action."
-            }
-        }
+    def test_unregistered_user_can_access_home(self, app):
+        # Regression test: this feature was found to block access to homepage
+        response = app.get('/')
+        assert response.status_code == 200
 
     def test_error_raised_for_non_sysadmin_user(self, app):
         user = factories.User(sysadmin=False)
@@ -39,13 +31,6 @@ class TestSysadminsOnlyCanAccessAPI():
 
 @pytest.mark.usefixtures("clean_db")
 class TestSubstituteUser():
-
-    def test_error_raised_for_unregistered_user(self, app):
-        response = app.get(
-            toolkit.url_for('api.action', ver=3, logic_function='package_list'),
-            headers={'CKAN-Substitute-User': 'fjelltopp_editor'}
-        )
-        assert response.status_code == 403
 
     def test_error_raised_for_non_sysadmin_user(self, app):
         user = factories.User(sysadmin=False)


### PR DESCRIPTION
At the moment we have locked access off to everything for everyone except sysadmins.  We should at least allow public users access to public pages. 